### PR TITLE
Fix Route::group bug

### DIFF
--- a/src/de/espend/idea/laravel/controller/ControllerCollector.java
+++ b/src/de/espend/idea/laravel/controller/ControllerCollector.java
@@ -27,37 +27,33 @@ public class ControllerCollector {
             addAll(PhpIndex.getInstance(project).getAllSubclasses("\\App\\Http\\Controllers\\Controller"));
         }};
 
-        String ns = prefix;
-        boolean prioritised = false;
-        if(prefix == null) {
-            ns = getDefaultNamespace(project);
-            prioritised = true;
-        }
+        String ns = getDefaultNamespace(project) + "\\";
+        String prefixedNs = ns + (prefix != null && !prefix.equals("") ? prefix + "\\":"");
 
         for(PhpClass phpClass: allSubclasses) {
             if(!phpClass.isAbstract()) {
                 for(Method method: phpClass.getMethods()) {
                     String className = phpClass.getPresentableFQN();
-                    if(className != null) {
-                        String methodName = method.getName();
-                        if(!method.isStatic() && method.getAccess().isPublic() && !methodName.startsWith("__")) {
-                            PhpClass phpTrait = method.getContainingClass();
-                            if(phpTrait == null || !("ValidatesRequests".equals(phpTrait.getName()) || "DispatchesCommands".equals(phpTrait.getName()) || "Controller".equals(phpTrait.getName()))) {
+                    String methodName = method.getName();
+                    if(!method.isStatic() && method.getAccess().isPublic() && !methodName.startsWith("__")) {
+                        PhpClass phpTrait = method.getContainingClass();
+                        if(phpTrait == null || !("ValidatesRequests".equals(phpTrait.getName()) || "DispatchesCommands".equals(phpTrait.getName()) || "Controller".equals(phpTrait.getName()))) {
 
-                                if(className.startsWith(ns + "\\")) {
-                                    className = className.substring(ns.length() + 1);
-                                }
+                            boolean prioritised = false;
+                            if(prefix != null && className.startsWith(prefixedNs)) {
+                                className = className.substring(prefixedNs.length());
+                                prioritised = true;
+                            } else if(className.startsWith(ns)) {
+                                className = className.substring(ns.length());
+                            }
 
-                                if(StringUtils.isNotBlank(className)) {
-                                    visitor.visit(method, className + "@" + methodName, prioritised);
-                                }
+                            if(StringUtils.isNotBlank(className)) {
+                                visitor.visit(method, className + "@" + methodName, prioritised);
                             }
                         }
                     }
-
                 }
             }
-
         }
     }
 
@@ -69,7 +65,7 @@ public class ControllerCollector {
             return StringUtils.stripStart(controllerNamespace, "\\");
         }
 
-        for (PhpClass providerPhpClass: PhpIndex.getInstance(project).getAllSubclasses("\\Illuminate\\Foundation\\Support\\Providers\\RouteServiceProvider")) {
+        for(PhpClass providerPhpClass: PhpIndex.getInstance(project).getAllSubclasses("\\Illuminate\\Foundation\\Support\\Providers\\RouteServiceProvider")) {
 
             Field namespace = providerPhpClass.findOwnFieldByName("namespace", false);
             if(namespace == null) {
@@ -101,12 +97,8 @@ public class ControllerCollector {
             addAll(PhpIndex.getInstance(project).getAllSubclasses("\\App\\Http\\Controllers\\Controller"));
         }};
 
-        String ns = prefix;
-        boolean prioritised = false;
-        if(prefix == null) {
-            ns = getDefaultNamespace(project);
-            prioritised = true;
-        }
+        String ns = getDefaultNamespace(project) + "\\";
+        String prefixedNs = ns + (prefix != null && !prefix.equals("") ? prefix + "\\":"");
 
         for(PhpClass phpClass: allSubclasses) {
 
@@ -115,12 +107,13 @@ public class ControllerCollector {
             }
 
             String className = phpClass.getPresentableFQN();
-            if(className == null) {
-                continue;
-            }
 
-            if(className.startsWith(ns + "\\")) {
-                className = className.substring(ns.length() + 1);
+            boolean prioritised = false;
+            if(prefix != null && className.startsWith(prefixedNs)) {
+                className = className.substring(prefixedNs.length());
+                prioritised = true;
+            } else if(className.startsWith(ns)) {
+                className = className.substring(ns.length());
             }
 
             if(StringUtils.isNotBlank(className)) {

--- a/tests/de/espend/idea/laravel/tests/controller/ControllerReferencesTest.java
+++ b/tests/de/espend/idea/laravel/tests/controller/ControllerReferencesTest.java
@@ -27,7 +27,7 @@ public class ControllerReferencesTest extends LaravelLightCodeInsightFixtureTest
     public void testRouteParameter() {
         assertCompletionContains(PhpFileType.INSTANCE, "<?php\n" +
             "Route::get(null, '<caret>');\n",
-            "FooController@foo", "Foo\\Controllers\\BarController@foo"
+            "FooController@foo", "Foo\\Controllers\\BarController@foo", "Group\\GroupController@foo"
         );
 
         assertNavigationMatch(PhpFileType.INSTANCE, "<?php\n" +
@@ -46,42 +46,42 @@ public class ControllerReferencesTest extends LaravelLightCodeInsightFixtureTest
                 "Route::get('/', [\n" +
                 "  'uses' => '<caret>', \n" +
                 "]);",
-            "FooController@foo", "Foo\\Controllers\\BarController@foo"
+            "FooController@foo", "Foo\\Controllers\\BarController@foo", "Group\\GroupController@foo"
         );
     }
 
     public void testRouteGroups() {
         assertCompletionContains(PhpFileType.INSTANCE, "<?php\n" +
-                "Route::group(['namespace' => 'Foo\\Controllers'], function() {\n" +
+                "Route::group(['namespace' => 'Group'], function() {\n" +
                 "    Route::get('/', '<caret>');\n" +
                 "});",
-            "BarController@foo"
+            "GroupController@foo"
         );
 
         assertNavigationMatch(PhpFileType.INSTANCE, "<?php\n" +
-                "Route::group(['namespace' => 'Foo\\Controllers'], function() {\n" +
-                "    Route::get('/', 'BarController@foo<caret>');\n" +
+                "Route::group(['namespace' => 'Group'], function() {\n" +
+                "    Route::get('/', 'GroupController@foo<caret>');\n" +
                 "});",
             PlatformPatterns.psiElement(Method.class).withParent(
-                PlatformPatterns.psiElement(PhpClass.class).withName("BarController")
+                PlatformPatterns.psiElement(PhpClass.class).withName("GroupController")
             )
         );
     }
 
     public void testRouteGroupsStartsWithBackslashRemovesFirstChar() {
         assertCompletionContains(PhpFileType.INSTANCE, "<?php\n" +
-                "Route::group(['namespace' => '\\Foo\\Controllers'], function() {\n" +
+                "Route::group(['namespace' => '\\Group'], function() {\n" +
                 "    Route::get('/', '<caret>');\n" +
                 "});",
-            "BarController@foo"
+            "GroupController@foo"
         );
 
         assertNavigationMatch(PhpFileType.INSTANCE, "<?php\n" +
-                "Route::group(['namespace' => '\\Foo\\Controllers'], function() {\n" +
-                "    Route::get('/', 'BarController@foo<caret>');\n" +
+                "Route::group(['namespace' => '\\Group'], function() {\n" +
+                "    Route::get('/', 'GroupController@foo<caret>');\n" +
                 "});",
             PlatformPatterns.psiElement(Method.class).withParent(
-                PlatformPatterns.psiElement(PhpClass.class).withName("BarController")
+                PlatformPatterns.psiElement(PhpClass.class).withName("GroupController")
             )
         );
     }

--- a/tests/de/espend/idea/laravel/tests/controller/fixtures/routing.php
+++ b/tests/de/espend/idea/laravel/tests/controller/fixtures/routing.php
@@ -38,6 +38,14 @@ namespace App\Http\Controllers
     }
 }
 
+namespace App\Http\Controllers\Group
+{
+    class GroupController implements \App\Http\Controllers\Controller
+    {
+        public function foo() {}
+    }
+}
+
 namespace Foo\Controllers
 {
     class BarController implements \App\Http\Controllers\Controller


### PR DESCRIPTION
Tests are fixed. Laravel doesn't allow Route::group for controllers not in default namespace. So only default "namespace + prefix" or "default namespace" could be cut.

I also deleted unnecessary "className != null" checks. PhpClass.getPresentableFQN() is @NotNull