### PR TITLE
Fixed duplicates in @lang blade directive

### DIFF
--- a/src/de/espend/idea/laravel/blade/BladeDirectiveReferences.java
+++ b/src/de/espend/idea/laravel/blade/BladeDirectiveReferences.java
@@ -75,20 +75,6 @@ public class BladeDirectiveReferences implements GotoCompletionRegistrar {
 
         });
 
-        // @lang('lang.foo')
-        registrar.register(PlatformPatterns.psiElement().inVirtualFile(PlatformPatterns.virtualFile().withName(PlatformPatterns.string().endsWith("blade.php"))), psiElement -> {
-            if(psiElement == null || !LaravelProjectComponent.isEnabled(psiElement)) {
-                return null;
-            }
-
-            if(BladePsiUtil.isDirectiveWithInstance(psiElement, "Illuminate\\Support\\Facades\\Lang", "get")) {
-                return new TranslationReferences.TranslationKey(psiElement);
-            }
-
-            return null;
-
-        });
-
         // @push('my_stack')
         registrar.register(PlatformPatterns.psiElement().inVirtualFile(PlatformPatterns.virtualFile().withName(PlatformPatterns.string().endsWith("blade.php"))), psiElement -> {
             if(psiElement == null || !LaravelProjectComponent.isEnabled(psiElement)) {

--- a/src/de/espend/idea/laravel/translation/TranslationReferences.java
+++ b/src/de/espend/idea/laravel/translation/TranslationReferences.java
@@ -14,6 +14,7 @@ import com.jetbrains.php.lang.PhpLanguage;
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
 import de.espend.idea.laravel.LaravelIcons;
 import de.espend.idea.laravel.LaravelProjectComponent;
+import de.espend.idea.laravel.blade.util.BladePsiUtil;
 import de.espend.idea.laravel.stub.TranslationKeyStubIndex;
 import de.espend.idea.laravel.stub.processor.CollectProjectUniqueKeys;
 import de.espend.idea.laravel.translation.utils.TranslationUtil;
@@ -52,6 +53,11 @@ public class TranslationReferences implements GotoCompletionLanguageRegistrar {
                 MethodMatcher.getMatchedSignatureWithDepth(parent, TRANSLATION_KEY) != null || PhpElementsUtil.isFunctionReference(parent, 0, "trans", "__", "trans_choice")
             )) {
                 return new TranslationKey(parent);
+            }
+
+            // for blade @lang directive
+            if(BladePsiUtil.isDirectiveWithInstance(psiElement, "Illuminate\\Support\\Facades\\Lang", "get")) {
+                return new TranslationKey(psiElement);
             }
 
             return null;


### PR DESCRIPTION
Fixes #127 
If _ide_helper.php exists PhpStorm now understands that Lang::get is the same as Translator::get and we had 2 identical TranslationKey goto completion providers. So I decided to move them all to one place, so if it hits to one of it, it won't hit to another.