### PR TITLE
Re-use constant instead of setting up new PsiElement array instances

### DIFF
--- a/src/main/java/de/espend/idea/laravel/util/PsiElementUtils.java
+++ b/src/main/java/de/espend/idea/laravel/util/PsiElementUtils.java
@@ -29,7 +29,7 @@ public class PsiElementUtils {
 
         PsiElement startElement = psiElement.getFirstChild();
         if(startElement == null) {
-            return new PsiElement[0];
+            return PsiElement.EMPTY_ARRAY;
         }
 
         psiElements.add(startElement);

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/codeInsight/navigation/GotoHandler.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/codeInsight/navigation/GotoHandler.java
@@ -20,7 +20,7 @@ public class GotoHandler implements GotoDeclarationHandler {
     public PsiElement[] getGotoDeclarationTargets(PsiElement psiElement, int i, Editor editor) {
 
         if (!LaravelProjectComponent.isEnabled(psiElement)) {
-            return new PsiElement[0];
+            return PsiElement.EMPTY_ARRAY;
         }
 
         Collection<PsiElement> psiTargets = new ArrayList<PsiElement>();


### PR DESCRIPTION
Instead of allocating empty array instances, re-use the constant `PsiElement#EMPTY_ARRAY`.