### PR TITLE
Use Collections.singleton to avoid new HashSet creation

### DIFF
--- a/src/main/java/de/espend/idea/laravel/blade/BladeDirectiveReferences.java
+++ b/src/main/java/de/espend/idea/laravel/blade/BladeDirectiveReferences.java
@@ -309,7 +309,7 @@ public class BladeDirectiveReferences implements GotoCompletionRegistrar {
 
             FileBasedIndex.getInstance().getFilesWithKey(
                     BladeCustomDirectivesStubIndex.KEY,
-                    new HashSet<>(Collections.singletonList(directiveName)),
+                    Collections.singleton(directiveName),
                     virtualFile -> {
 
                         PsiFile psiFile = PsiManager.getInstance(getProject()).findFile(virtualFile);

--- a/src/main/java/de/espend/idea/laravel/blade/TemplateLineMarker.java
+++ b/src/main/java/de/espend/idea/laravel/blade/TemplateLineMarker.java
@@ -207,7 +207,7 @@ public class TemplateLineMarker implements LineMarkerProvider {
         AtomicBoolean includeLineMarker = new AtomicBoolean(false);
         for(ID<String, Void> key : Arrays.asList(BladeExtendsStubIndex.KEY, BladeSectionStubIndex.KEY, BladeIncludeStubIndex.KEY, BladeEachStubIndex.KEY)) {
             for(String templateName: templateNames) {
-                FileBasedIndex.getInstance().getFilesWithKey(key, new HashSet<>(Collections.singletonList(templateName)), virtualFile -> {
+                FileBasedIndex.getInstance().getFilesWithKey(key, Collections.singleton(templateName), virtualFile -> {
                     includeLineMarker.set(true);
 
                     // stop on first file match
@@ -507,7 +507,7 @@ public class TemplateLineMarker implements LineMarkerProvider {
 
             for(ID<String, Void> key : Arrays.asList(BladeExtendsStubIndex.KEY, BladeSectionStubIndex.KEY, BladeIncludeStubIndex.KEY, BladeEachStubIndex.KEY)) {
                 for(String templateName: templateNames) {
-                    FileBasedIndex.getInstance().getFilesWithKey(key, new HashSet<>(Collections.singletonList(templateName)), virtualFile -> {
+                    FileBasedIndex.getInstance().getFilesWithKey(key, Collections.singleton(templateName), virtualFile -> {
                         virtualFiles.add(virtualFile);
                         return true;
                     }, GlobalSearchScope.getScopeRestrictedByFileTypes(GlobalSearchScope.allScope(project), BladeFileType.INSTANCE));

--- a/src/main/java/de/espend/idea/laravel/blade/util/BladeTemplateUtil.java
+++ b/src/main/java/de/espend/idea/laravel/blade/util/BladeTemplateUtil.java
@@ -189,7 +189,7 @@ public class BladeTemplateUtil {
         }
 
         int finalDepth = depth;
-        FileBasedIndex.getInstance().getFilesWithKey(BladeExtendsStubIndex.KEY, new HashSet<>(Collections.singletonList(templateName)), virtualFile -> {
+        FileBasedIndex.getInstance().getFilesWithKey(BladeExtendsStubIndex.KEY, Collections.singleton(templateName), virtualFile -> {
             if (!virtualFiles.contains(virtualFile)) {
                 virtualFiles.add(virtualFile);
                 for (String nextTpl : BladeTemplateUtil.resolveTemplateName(project, virtualFile)) {

--- a/src/main/java/de/espend/idea/laravel/config/AppConfigReferences.java
+++ b/src/main/java/de/espend/idea/laravel/config/AppConfigReferences.java
@@ -92,7 +92,7 @@ public class AppConfigReferences implements GotoCompletionLanguageRegistrar {
                 return targets;
             }
 
-            FileBasedIndex.getInstance().getFilesWithKey(ConfigKeyStubIndex.KEY, new HashSet<>(Collections.singletonList(contents)), virtualFile -> {
+            FileBasedIndex.getInstance().getFilesWithKey(ConfigKeyStubIndex.KEY, Collections.singletonList(contents), virtualFile -> {
                 PsiFile psiFileTarget = PsiManager.getInstance(getProject()).findFile(virtualFile);
                 if(psiFileTarget == null) {
                     return true;

--- a/src/main/java/de/espend/idea/laravel/config/AppConfigReferences.java
+++ b/src/main/java/de/espend/idea/laravel/config/AppConfigReferences.java
@@ -92,7 +92,7 @@ public class AppConfigReferences implements GotoCompletionLanguageRegistrar {
                 return targets;
             }
 
-            FileBasedIndex.getInstance().getFilesWithKey(ConfigKeyStubIndex.KEY, Collections.singletonList(contents), virtualFile -> {
+            FileBasedIndex.getInstance().getFilesWithKey(ConfigKeyStubIndex.KEY, Collections.singleton(contents), virtualFile -> {
                 PsiFile psiFileTarget = PsiManager.getInstance(getProject()).findFile(virtualFile);
                 if(psiFileTarget == null) {
                     return true;

--- a/src/main/java/de/espend/idea/laravel/routing/utils/RoutingUtil.java
+++ b/src/main/java/de/espend/idea/laravel/routing/utils/RoutingUtil.java
@@ -50,7 +50,7 @@ public class RoutingUtil {
         Set<VirtualFile> virtualFiles = new HashSet<>();
 
         // find files with route name
-        FileBasedIndex.getInstance().getFilesWithKey(RouteIndexExtension.KEY, new HashSet<>(Collections.singletonList(routeName)), virtualFile -> {
+        FileBasedIndex.getInstance().getFilesWithKey(RouteIndexExtension.KEY, Collections.singleton(routeName), virtualFile -> {
             virtualFiles.add(virtualFile);
             return true;
         }, GlobalSearchScope.getScopeRestrictedByFileTypes(GlobalSearchScope.allScope(project), PhpFileType.INSTANCE));

--- a/src/main/java/de/espend/idea/laravel/translation/TranslationReferences.java
+++ b/src/main/java/de/espend/idea/laravel/translation/TranslationReferences.java
@@ -105,7 +105,7 @@ public class TranslationReferences implements GotoCompletionLanguageRegistrar {
             final Set<PsiElement> priorityTargets = new LinkedHashSet<>();
             final Set<PsiElement> targets = new LinkedHashSet<>();
 
-            FileBasedIndex.getInstance().getFilesWithKey(TranslationKeyStubIndex.KEY, new HashSet<>(Collections.singletonList(contents)), virtualFile -> {
+            FileBasedIndex.getInstance().getFilesWithKey(TranslationKeyStubIndex.KEY, Collections.singleton(contents), virtualFile -> {
                 PsiFile psiFileTarget = PsiManager.getInstance(getProject()).findFile(virtualFile);
                 if(psiFileTarget == null) {
                     return true;


### PR DESCRIPTION
`Collections.singleton` creates a more optimal, one-element `Set` instance.