### PR TITLE
Handle "multiple class definitions" by preferring definitions from _ide_helper.php

### DIFF
--- a/src/main/java/de/espend/idea/laravel/ReferenceResolver2.java
+++ b/src/main/java/de/espend/idea/laravel/ReferenceResolver2.java
@@ -1,0 +1,22 @@
+package de.espend.idea.laravel;
+
+import com.jetbrains.php.lang.psi.elements.PhpNamedElement;
+import com.jetbrains.php.lang.psi.elements.PhpReference;
+import com.jetbrains.php.lang.psi.resolve.PhpReferenceResolver2;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@SuppressWarnings("UnstableApiUsage")
+public class ReferenceResolver2 implements PhpReferenceResolver2 {
+    @Override
+    public Collection<? extends PhpNamedElement> resolve(PhpReference phpReference, Collection<? extends PhpNamedElement> candidates) {
+        if (candidates.size()>1) {
+            for (PhpNamedElement element : candidates) {
+                if (element.getContainingFile().getVirtualFile().getName().equals("_ide_helper.php"))
+                    return Collections.singleton(element);
+            }
+        }
+        return candidates;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -80,6 +80,7 @@
     <extensions defaultExtensionNs="com.jetbrains.php">
         <typeProvider3 implementation="de.espend.idea.laravel.blade.BladeInjectTypeProvider"/>
         <typeProvider3 implementation="de.espend.idea.laravel.dic.DicTypeProvider"/>
+        <referenceResolver2 implementation="de.espend.idea.laravel.ReferenceResolver2"/>
     </extensions>
 
   <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
It seems that I had created relevant API in PhpStorm a year ago. Here is a sample usage...