### PR TITLE
Add model factory type provider

### DIFF
--- a/src/main/java/de/espend/idea/laravel/factory/ModelFactoryTypeProvider.java
+++ b/src/main/java/de/espend/idea/laravel/factory/ModelFactoryTypeProvider.java
@@ -1,0 +1,120 @@
+package de.espend.idea.laravel.factory;
+
+import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.php.PhpIndex;
+import com.jetbrains.php.lang.psi.elements.*;
+import com.jetbrains.php.lang.psi.elements.impl.FunctionReferenceImpl;
+import com.jetbrains.php.lang.psi.elements.impl.VariableImpl;
+import com.jetbrains.php.lang.psi.resolve.types.PhpType;
+import com.jetbrains.php.lang.psi.resolve.types.PhpTypeProvider4;
+import de.espend.idea.laravel.LaravelSettings;
+import de.espend.idea.laravel.factory.utils.ModelFactoryTypeProviderUtil;
+import fr.adrienbrault.idea.symfony2plugin.util.PhpTypeProviderUtil;
+import org.apache.commons.lang.StringUtils;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Set;
+
+public class ModelFactoryTypeProvider implements PhpTypeProvider4 {
+    private final static char TRIM_KEY = '\u0253';
+    private final static char SPLIT_KEY = '\u0254';
+
+    @Override
+    public char getKey() {
+        return '\u0263';
+    }
+
+    private static boolean isElementValid(PsiElement e) {
+        if (!(e instanceof MethodReference)) {
+            return false;
+        }
+
+        String methodRefName = ((MethodReference) e).getName();
+
+        if (methodRefName == null) {
+            return false;
+        }
+
+        if (!Arrays.asList("create", "make").contains(methodRefName)) return false;
+
+        if (StringUtils.isEmpty(((MethodReference) e).getSignature())) return false;
+
+        PsiElement target = ((MethodReference) e).resolve();
+
+        if (!(target instanceof Method)) {
+            return false;
+        }
+
+        PhpClass containingClass = ((Method) target).getContainingClass();
+
+        if (containingClass == null) {
+            return false;
+        }
+
+        return "\\Illuminate\\Database\\Eloquent\\FactoryBuilder".equals(containingClass.getFQN());
+    }
+
+    @Override @Nullable
+    public PhpType getType(PsiElement e) {
+        if (DumbService.getInstance(e.getProject()).isDumb() || !LaravelSettings.getInstance(e.getProject()).pluginEnabled) {
+            return null;
+        }
+
+        if (!isElementValid(e)) {
+            return null;
+        }
+
+        PsiElement firstPsiChild = PsiTreeUtil.findChildOfAnyType(e, FunctionReferenceImpl.class, VariableImpl.class);
+
+        if (firstPsiChild instanceof FunctionReferenceImpl) {
+            String refSignature = ModelFactoryTypeProviderUtil.getRefSig((FunctionReference) firstPsiChild, TRIM_KEY, SPLIT_KEY);
+            if (refSignature == null) {
+                return null;
+            }
+
+            return new PhpType().add("#" + this.getKey() + TRIM_KEY + refSignature);
+        } else if (firstPsiChild instanceof VariableImpl) {
+            FunctionReference functionRef = ModelFactoryTypeProviderUtil.resolveFunctionRef((VariableImpl) firstPsiChild);
+
+            if (functionRef == null) {
+                return null;
+            }
+
+            String refSignature = ModelFactoryTypeProviderUtil.getRefSig(functionRef, TRIM_KEY, SPLIT_KEY);
+
+            return new PhpType().add("#" + this.getKey() + TRIM_KEY + refSignature);
+        }
+
+        return null;
+    }
+
+    @Override
+    public Collection<? extends PhpNamedElement> getBySignature(String sig, Set<String> set, int i, Project project) {
+        int endIndex = sig.lastIndexOf(TRIM_KEY);
+        if (endIndex == -1) {
+            return null;
+        }
+
+        String parameter = sig.substring(endIndex + 1);
+
+        PhpIndex index = PhpIndex.getInstance(project);
+
+        parameter = PhpTypeProviderUtil.getResolvedParameter(index, parameter);
+
+        if (parameter == null) {
+            return null;
+        }
+
+        Collection<PhpClass> classes = index.getClassesByFQN(parameter);
+
+        return classes.isEmpty() ? null : classes;
+    }
+
+    @Override @Nullable
+    public PhpType complete(String s, Project project) { return null; }
+}

--- a/src/main/java/de/espend/idea/laravel/factory/utils/ModelFactoryTypeProviderUtil.java
+++ b/src/main/java/de/espend/idea/laravel/factory/utils/ModelFactoryTypeProviderUtil.java
@@ -1,0 +1,95 @@
+package de.espend.idea.laravel.factory.utils;
+
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
+import com.jetbrains.php.lang.psi.elements.*;
+import com.jetbrains.php.lang.psi.elements.impl.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class ModelFactoryTypeProviderUtil {
+    private final static String COLLECTION_SIG = "\\Illuminate\\Database\\Eloquent\\Collection.class";
+
+    @Nullable
+    public static FunctionReferenceImpl resolveFunctionRef(@NotNull VariableImpl variable) {
+        AssignmentExpressionImpl assignment = getAssignmentExpr(variable);
+
+        return assignment != null ? (FunctionReferenceImpl) assignment.getValue() : null;
+    }
+
+    @Nullable
+    public static String getRefSig(FunctionReference functionReference, char trimKey, char splitKey) {
+
+        String refSignature = functionReference.getSignature();
+
+        if (StringUtil.isEmpty(refSignature)) {
+            return null;
+        }
+
+        PsiElement[] parameters = functionReference.getParameters();
+        if (parameters.length == 0) {
+            return null;
+        }
+
+        PsiElement parameter = parameters[0];
+
+        if (parameters.length > 1) {
+            return refSignature + trimKey + "#K#C" + COLLECTION_SIG;
+        }
+
+        return refSignature + trimKey + getRefSigFromParameter(parameter);
+    }
+
+    @Nullable
+    private static String getRefSigFromParameter(PsiElement parameter) {
+        if (parameter instanceof StringLiteralExpression) {
+            String param = ((StringLiteralExpression)parameter).getContents();
+
+            if (StringUtil.isEmpty(param)) {
+                return null;
+            }
+
+            return param;
+        }
+
+        if (parameter instanceof ClassConstantReference || parameter instanceof FieldReference) {
+            String signature = ((PhpReference) parameter).getSignature();
+
+            if (StringUtil.isEmpty(signature)) {
+                return null;
+            }
+
+            return signature;
+        }
+
+        if (parameter instanceof VariableImpl) {
+            AssignmentExpressionImpl assignment = getAssignmentExpr((VariableImpl) parameter);
+
+            if (assignment == null || assignment.getValue() == null) {
+                return null;
+            }
+
+            return getRefSigFromParameter(assignment.getValue());
+        }
+
+        return null;
+    }
+
+    @Nullable
+    private static AssignmentExpressionImpl getAssignmentExpr(@NotNull VariableImpl variable) {
+        PsiReference reference = variable.getReference();
+        if (reference == null) {
+            return null;
+        }
+
+        PsiElement target = reference.resolve();
+        if (target == null) {
+            return null;
+        }
+
+        PsiElement targetParent = target.getParent();
+
+        return targetParent instanceof AssignmentExpressionImpl ? (AssignmentExpressionImpl) targetParent : null;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -80,6 +80,7 @@
     <extensions defaultExtensionNs="com.jetbrains.php">
         <typeProvider3 implementation="de.espend.idea.laravel.blade.BladeInjectTypeProvider"/>
         <typeProvider3 implementation="de.espend.idea.laravel.dic.DicTypeProvider"/>
+        <typeProvider4 implementation="de.espend.idea.laravel.factory.ModelFactoryTypeProvider"/>
     </extensions>
 
   <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
Provides some type for most common `factory()` usage.

In all following cases IDE resolves `$user` as the `User` model.
```php
$user = factory(User::class)->create();
```

```php
$user = factory(User::class)->make();
```

```php
$user = factory(User::class)->state('some-state')->create();
```

```php
$user = factory(User::class)->state('deleted')->states(['deteled', 'signedUp'])->make();
```

```php
$userFactory = factory(User::class);
$user = $userFactory->state('deleted')->create();
```

```php
$type = User::class;
$user = factory($type)->create();
```

```php
$type = User::class;
$userFactory = factory($type);
$user = $userFactory->create();
```

```php
$user = factory('App\Model\User')->create();
```

In this case it resolves `$users` as `Illuminate\Database\Eloquent\Collection`
```php
$users = factory(User::class, 3)->create();
```