### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Changelog   | [CHANGELOG](CHANGELOG.md)
 
 To install,  go to `Settings > Plugins` and search for "Laravel Plugin".
 
-Once installed, you must activate per-project by going to `Settings > Languages & Frameworks > PHP > Laravel` and clicking "Enable for this project".
+Once installed, you must activate per-project by going to `Settings > PHP > Laravel` and clicking "Enable for this project".
 
 *Note* You must install and use the [Laravel IDE Helper](https://github.com/barryvdh/laravel-ide-helper) in order for PhpStorm to know how to find the Laravel classes.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Changelog   | [CHANGELOG](CHANGELOG.md)
 
 To install,  go to `Settings > Plugins` and search for "Laravel Plugin".
 
-Once installed, you must activate per-project by going to `Settings > PHP > Laravel` and clicking "Enable for this project".
+Once installed, you must activate per-project by going to `File > Settings > PHP > Laravel` and clicking "Enable plugin for this project".
 
 *Note* You must install and use the [Laravel IDE Helper](https://github.com/barryvdh/laravel-ide-helper) in order for PhpStorm to know how to find the Laravel classes.
 


### PR DESCRIPTION
The "PHP" settings section has been moved up from "Languages & Frameworks" in recent versions of PhpStorm.